### PR TITLE
IE8 Bug - no native JSON object

### DIFF
--- a/jQuery.XDomainRequest.js
+++ b/jQuery.XDomainRequest.js
@@ -39,7 +39,7 @@ if (!jQuery.support.cors && window.XDomainRequest) {
 						try {
 							if (userType === 'json') {
 								try {
-									responses.json = JSON.parse(xdr.responseText);
+									responses.json = jQuery.parseJSON(xdr.responseText);
 								} catch(e) {
 									status.code = 500;
 									status.message = 'parseerror';


### PR DESCRIPTION
You should use jQuery's parseJSON method instead, like this patch does.
