### PR TITLE
Requests using Protocol-less URLs fail

### DIFF
--- a/jQuery.XDomainRequest.js
+++ b/jQuery.XDomainRequest.js
@@ -67,8 +67,11 @@ if (!jQuery.support.cors && window.XDomainRequest) {
               complete(status.code, status.message, responses, allResponseHeaders);
             }
           };
+          
+          //set an empty handler for 'onprogress' so requests don't get aborted
           xdr.onprogress = function () {
           };
+
           xdr.onerror = function(){
             complete(500, 'error', {
               text: xdr.responseText


### PR DESCRIPTION
I found a problem wth using Protocol-less URLs (without http: or https:). Requests that use protocol-less urls never are started.

URL's like  "//api.example.com"  will never pass httpRegEx or sameSchemeRegEx. 

The fix is really simple. Just check against the url in the request options not in userOptions. jQuery takes care of adding the proper protocol to url when its missing.
