### PR TITLE
Fix for IE9 bug which causes some requests to abort

### DIFF
--- a/jQuery.XDomainRequest.js
+++ b/jQuery.XDomainRequest.js
@@ -20,6 +20,7 @@ if (!jQuery.support.cors && window.XDomainRequest) {
           if (/^\d+$/.test(userOptions.timeout)) {
             xdr.timeout = userOptions.timeout;
           }
+          xdr.onprogress = function(){};
           xdr.ontimeout = function(){
             complete(500, 'timeout');
           };


### PR DESCRIPTION
Note that setting this to a reference to jQuery.noop does not seem to work
See more info at https://github.com/jaubourg/ajaxHooks/pull/1
