### PR TITLE
support already serialized json as data

### DIFF
--- a/jQuery.XDomainRequest.js
+++ b/jQuery.XDomainRequest.js
@@ -74,7 +74,13 @@ if (!jQuery.support.cors && jQuery.ajaxTransport && window.XDomainRequest) {
               text: xdr.responseText
             });
           };
-          var postData = (userOptions.data && $.param(userOptions.data)) || '';
+          var postData = (
+              userOptions.data && (
+                  typeof userOptions.data === "string"
+                      ? userOptions.data
+                      : $.param(userOptions.data))
+                  )
+              || '';
           xdr.open(options.type, options.url);
           xdr.send(postData);
         },


### PR DESCRIPTION
When using something like 

``` javascript
$.ajax({
// ...
  data: JSON.stringify([{foo:bar}])
});
```

it failed.
