### PR TITLE
Fake successful response code to access error body

### DIFF
--- a/jQuery.XDomainRequest.js
+++ b/jQuery.XDomainRequest.js
@@ -41,6 +41,10 @@ if (!jQuery.support.cors && jQuery.ajaxTransport && window.XDomainRequest) {
               if ((userType === 'json') || ((userType !== 'text') && jsonRegEx.test(xdr.contentType))) {
                 try {
                   responses.json = jQuery.parseJSON(xdr.responseText);
+                  if(responses.json.status_code && responses.json.status_code >= 400){
+                    status.code = responses.json.status_code;
+                    status.message = responses.json.status;
+                  }
                 } catch(e) {
                   status.code = 500;
                   status.message = 'parseerror';
@@ -78,6 +82,8 @@ if (!jQuery.support.cors && jQuery.ajaxTransport && window.XDomainRequest) {
           if (userOptions.data) {
             postData = (jQuery.type(userOptions.data) === 'string') ? userOptions.data : jQuery.param(userOptions.data);
           }
+          // add in an extra param to force the response type to success for proper error handling
+          postData += '&xdr_force_response_status=200';
           xdr.open(options.type, options.url);
           xdr.send(postData);
         },


### PR DESCRIPTION
For non-successful responses, IE doesn't allow access to the response text (see http://stackoverflow.com/questions/10390539/xdomainrequest-get-response-body-on-error) so we're asking the server to always respond with 200, and to also add the real response code and message to the json response.

Note that this only works with JSON types at this time (that's what I needed, and tested with) and that it requires server-side changes.

This shouldn't affect other browser support, as the server should only override the status code if the xdr_force_response_status param is set.
