### PR TITLE
Removing processinginstruction node if it exists.

### DIFF
--- a/jQuery.XDomainRequest.js
+++ b/jQuery.XDomainRequest.js
@@ -59,6 +59,9 @@ if (!$.support.cors && $.ajaxTransport && window.XDomainRequest) {
                   status.message = 'parseerror';
                   throw 'Invalid XML: ' + xdr.responseText;
                 }
+                if (doc.firstChild.nodeTypeString === 'processinginstruction') {
+                  doc.removeChild(doc.firstChild);
+                }
                 responses.xml = doc;
               }
             } catch(parseMessage) {


### PR DESCRIPTION
Ran into an issue on IE9 when processing an XML response where the firstChild node would always be the processing instruction. (i.e. `<?xml version="1.0" encoding="UTF-8" ?>`) This simply removes it from the response if it exists and returns the body which is consistent with the behaviour in other modern browsers (tested in Chrome 33.0.1750.152).  
