### PR TITLE
Allow protocol-relative URLs

### DIFF
--- a/jQuery.XDomainRequest.js
+++ b/jQuery.XDomainRequest.js
@@ -22,13 +22,13 @@ if ($.support.cors || !$.ajaxTransport || !window.XDomainRequest) {
   return;
 }
 
-var httpRegEx = /^https?:\/\//i;
+var httpRegEx = /^(https?:)?\/\//i;
 var getOrPostRegEx = /^get|post$/i;
-var sameSchemeRegEx = new RegExp('^'+location.protocol, 'i');
+var sameSchemeRegEx = new RegExp('^(\/\/|' + location.protocol + ')', 'i');
 
 // ajaxTransport exists in jQuery 1.5+
 $.ajaxTransport('* text html xml json', function(options, userOptions, jqXHR) {
-  
+
   // Only continue if the request is: asynchronous, uses GET or POST method, has HTTP or HTTPS protocol, and has the same scheme as the calling page
   if (!options.crossDomain || !options.async || !getOrPostRegEx.test(options.type) || !httpRegEx.test(options.url) || !sameSchemeRegEx.test(options.url)) {
     return;


### PR DESCRIPTION
jQuery-ajaxTransport-XDomainRequest fails when used together with protocol-relative URLS like `//example.com`.

This PR intends to fix that.

@MoonScript What JS minifier are you using?
