### PR TITLE
Loop jQuery object trough

### DIFF
--- a/jQuery.XDomainRequest.js
+++ b/jQuery.XDomainRequest.js
@@ -19,7 +19,7 @@
 
 // Only continue if we're on IE8/IE9 with jQuery 1.5+ (contains the ajaxTransport function)
 if ($.support.cors || !$.ajaxTransport || !window.XDomainRequest) {
-  return;
+  return $;
 }
 
 var httpRegEx = /^https?:\/\//i;
@@ -113,5 +113,7 @@ $.ajaxTransport('* text html xml json', function(options, userOptions, jqXHR) {
     }
   };
 });
+
+return $;
 
 }));


### PR DESCRIPTION
We are using your library in a current project with RequireJS. I spontaneously used your library directly instead of jQuery as follows:

```
require(
	[
		'jquery.xdomainrequest',
	],
	function($) {
		// jQuery now present and has CORS support within IE8/IE9
	}
);
```

In the current version it does not work, because the potentially patched jQuery object isn't returned. My change does "fix" it.