### PR TITLE
Sending cookie data in payload when requested

### DIFF
--- a/jQuery.XDomainRequest.js
+++ b/jQuery.XDomainRequest.js
@@ -34,6 +34,12 @@ $.ajaxTransport('* text html xml json', function(options, userOptions, jqXHR) {
     return;
   }
 
+  // XDomainRequest does not send any headers, so we are sending cookie data in payload when credentials are requested
+  if(options.type === 'POST' && options.sendCookieInPayload && options.xhrFields.withCredentials) {
+    userOptions.data = userOptions.data || {};
+    userOptions.data.cookie = document.cookie;
+  }
+  
   var xdr = null;
 
   return {


### PR DESCRIPTION
XDomainRequest is limited and won't send any headers. It's now possible to send cookie data in payload (away from sniffers) using POST request and setting sendCookieInPayload in jQuery ajax options to true.

Some extra code will be needed in the REST endpoint to turn this data useful.
